### PR TITLE
Add golangci-linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.49

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+run:
+  timeout: 5m
+  go: "1.19"
+  skip-files:
+    -  ".*\\_test\\.go$" # ignore test files for now

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ buildx-deploy: ## Build multi-platform buz image and push it to edge repo
 	docker buildx use $(S)
 	docker buildx build --platform linux/arm64,linux/amd64 -f deploy/Dockerfile -t $(REGISTRY)/buz:$(VERSION)-edge . --push
 
+lint: ## Lint go code
+	@golangci-lint run --config .golangci.yml
+
 test-cover-pkg: ## Run tests against pkg, output test profile, and open profile in browser
 	go test ./pkg/... -v -coverprofile=$(TEST_PROFILE) || true
 	go tool cover -html=$(TEST_PROFILE) || true

--- a/cmd/buz/app.go
+++ b/cmd/buz/app.go
@@ -68,12 +68,13 @@ func (a *App) configure() {
 	viper.SetConfigFile(conf)
 	viper.SetConfigType("yaml")
 	err := viper.ReadInConfig()
-
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("could not read config")
 	}
 	a.config = &config.Config{}
-	viper.Unmarshal(a.config)
+	if err := viper.Unmarshal(a.config); err != nil {
+		log.Fatal().Stack().Err(err).Msg("could not unmarshal config")
+	}
 	gin.SetMode(a.config.App.Mode)
 	if gin.IsDebugging() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
@@ -93,7 +94,9 @@ func (a *App) initializeStats() {
 func (a *App) initializeSchemaCache() {
 	log.Info().Msg("🟢 initializing schema cache")
 	cache := cache.SchemaCache{}
-	cache.Initialize(a.config.SchemaCache)
+	if err := cache.Initialize(a.config.SchemaCache); err != nil {
+		panic(err)
+	}
 	a.schemaCache = &cache
 }
 
@@ -119,7 +122,9 @@ func (a *App) initializeManifold() {
 func (a *App) initializeRouter() {
 	log.Info().Msg("🟢 initializing router")
 	a.engine = gin.New()
-	a.engine.SetTrustedProxies(nil)
+	if err := a.engine.SetTrustedProxies(nil); err != nil {
+		panic(err)
+	}
 	a.engine.RedirectTrailingSlash = false
 }
 

--- a/pkg/cache/backendFilesystem.go
+++ b/pkg/cache/backendFilesystem.go
@@ -5,7 +5,7 @@
 package cache
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
@@ -25,7 +25,7 @@ func (b *FilesystemCacheBackend) Initialize(conf config.Backend) error {
 
 func (b *FilesystemCacheBackend) GetRemote(schema string) (contents []byte, err error) {
 	schemaLocation := filepath.Join(b.path, schema)
-	content, err := ioutil.ReadFile(schemaLocation)
+	content, err := os.ReadFile(schemaLocation)
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not get schema from filesystem schema cache backend: " + schemaLocation)
 		return nil, err

--- a/pkg/cache/backendGcs.go
+++ b/pkg/cache/backendGcs.go
@@ -6,7 +6,7 @@ package cache
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"cloud.google.com/go/storage"
@@ -46,7 +46,7 @@ func (b *GcsSchemaCacheBackend) GetRemote(schema string) (contents []byte, err e
 		log.Error().Err(err).Msg("🔴 could not get file from gcs: " + schemaLocation)
 		return nil, err
 	}
-	data, _ := ioutil.ReadAll(reader)
+	data, _ := io.ReadAll(reader)
 	return data, nil
 }
 

--- a/pkg/cache/backendMinio.go
+++ b/pkg/cache/backendMinio.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"github.com/minio/minio-go/v7"
@@ -53,7 +53,7 @@ func (b *MinioSchemaCacheBackend) GetRemote(schema string) (contents []byte, err
 		log.Error().Err(err).Msg("🔴 could not get file from minio: " + schemaLocation)
 		return nil, err
 	}
-	contents, err = ioutil.ReadAll(obj)
+	contents, err = io.ReadAll(obj)
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not read contents from file: " + schemaLocation)
 		return nil, err

--- a/pkg/envelope/builderCloudevent.go
+++ b/pkg/envelope/builderCloudevent.go
@@ -5,7 +5,7 @@
 package envelope
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -18,7 +18,7 @@ import (
 
 func BuildCloudeventEnvelopesFromRequest(c *gin.Context, conf *config.Config, m *meta.CollectorMeta) []Envelope {
 	var envelopes []Envelope
-	reqBody, err := ioutil.ReadAll(c.Request.Body)
+	reqBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not read request body")
 		return envelopes

--- a/pkg/envelope/builderGeneric.go
+++ b/pkg/envelope/builderGeneric.go
@@ -5,7 +5,7 @@
 package envelope
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -18,7 +18,7 @@ import (
 
 func BuildGenericEnvelopesFromRequest(c *gin.Context, conf *config.Config, m *meta.CollectorMeta) []Envelope {
 	var envelopes []Envelope
-	reqBody, err := ioutil.ReadAll(c.Request.Body)
+	reqBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not read request body")
 		return envelopes

--- a/pkg/envelope/builderSnowplow.go
+++ b/pkg/envelope/builderSnowplow.go
@@ -5,7 +5,7 @@
 package envelope
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -93,7 +93,7 @@ func buildSnowplowEnvelope(c *gin.Context, conf *config.Config, e snowplow.Snowp
 func BuildSnowplowEnvelopesFromRequest(c *gin.Context, conf *config.Config, m *meta.CollectorMeta) []Envelope {
 	var envelopes []Envelope
 	if c.Request.Method == "POST" {
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			log.Error().Err(err).Msg("🔴 could not read request body")
 			return envelopes

--- a/pkg/envelope/builderWebhook.go
+++ b/pkg/envelope/builderWebhook.go
@@ -5,7 +5,7 @@
 package envelope
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -18,7 +18,7 @@ import (
 
 func BuildWebhookEnvelopesFromRequest(c *gin.Context, conf *config.Config, m *meta.CollectorMeta) []Envelope {
 	var envelopes []Envelope
-	reqBody, err := ioutil.ReadAll(c.Request.Body)
+	reqBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not read request body")
 		return envelopes

--- a/pkg/envelope/envelope.go
+++ b/pkg/envelope/envelope.go
@@ -40,7 +40,9 @@ func (e *Envelope) AsMap() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	json.Unmarshal(marshaledEnvelope, &m)
+	if err := json.Unmarshal(marshaledEnvelope, &m); err != nil {
+		return nil, err
+	}
 	return m, nil
 }
 

--- a/pkg/handler/health_test.go
+++ b/pkg/handler/health_test.go
@@ -6,7 +6,7 @@ package handler
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -28,7 +28,7 @@ func TestHealthcheckHandler(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf(`HealthcheckHandler returned status code %v, want %v`, resp.StatusCode, http.StatusOK)
 	}
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 	marshaledB, _ := json.Marshal(response.Ok)
 	equiv := reflect.DeepEqual(b, marshaledB)
 	if !equiv {

--- a/pkg/handler/stats_test.go
+++ b/pkg/handler/stats_test.go
@@ -6,7 +6,7 @@ package handler
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -43,7 +43,7 @@ func TestStatsHandler(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf(`StatsHandler returned %d, want %d`, resp.StatusCode, http.StatusOK)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Could not read response: %v", err)
 	}

--- a/pkg/middleware/rateLimiter_test.go
+++ b/pkg/middleware/rateLimiter_test.go
@@ -6,7 +6,7 @@ package middleware
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,7 +45,7 @@ func TestOnLimitReachedHandler(t *testing.T) {
 
 	onLimitReachedHandler(c)
 
-	body, _ := ioutil.ReadAll(rec.Body)
+	body, _ := io.ReadAll(rec.Body)
 	wantBody, _ := json.Marshal(response.RateLimitExceeded)
 	assert.Equal(t, http.StatusTooManyRequests, rec.Result().StatusCode)
 	assert.Equal(t, wantBody, body)

--- a/pkg/middleware/timeout_test.go
+++ b/pkg/middleware/timeout_test.go
@@ -6,7 +6,7 @@ package middleware
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -57,7 +57,7 @@ func TestTimeout(t *testing.T) {
 			t.Fatalf(`got status code %v, want %v`, resp.StatusCode, tc.wantCode)
 		}
 		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		bodyEquiv := reflect.DeepEqual(body, tc.wantResponse)
 		if !bodyEquiv {
 			t.Fatalf(`got response %v, want %v`, body, tc.wantResponse)

--- a/pkg/middleware/yeet.go
+++ b/pkg/middleware/yeet.go
@@ -6,6 +6,7 @@ package middleware
 
 import "github.com/gin-gonic/gin"
 
+// nolint: unused
 type yeet struct {
 	Msg string
 }

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -6,7 +6,7 @@ package request
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -35,7 +35,7 @@ func TestPostEvent(t *testing.T) {
 		if d != u {
 			t.Fatalf(`posted payload to url %v, want %v`, d, u)
 		}
-		sentPayload, _ := ioutil.ReadAll(r.Body)
+		sentPayload, _ := io.ReadAll(r.Body)
 		payloadsEquiv := reflect.DeepEqual(sentPayload, marshaledPayload)
 		if !payloadsEquiv {
 			t.Fatalf(`posted body %v, want %v`, sentPayload, marshaledPayload)

--- a/pkg/sink/file.go
+++ b/pkg/sink/file.go
@@ -50,7 +50,7 @@ func (s *FileSink) Initialize(conf config.Sink) error {
 
 func (s *FileSink) batchPublish(ctx context.Context, filePath string, envelopes []envelope.Envelope) error {
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	defer f.Close()
+	defer f.Close() // nolint
 	if err != nil {
 		log.Error().Err(err).Msg("🔴 could not open file")
 		return err
@@ -64,7 +64,9 @@ func (s *FileSink) batchPublish(ctx context.Context, filePath string, envelopes 
 		}
 		newline := []byte("\n")
 		b = append(b, newline...)
-		f.Write(b)
+		if _, err := f.Write(b); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/sink/pubnub.go
+++ b/pkg/sink/pubnub.go
@@ -29,8 +29,8 @@ type PubnubSink struct {
 	invalidChannel   string
 	pubKey           string
 	subKey           string
-	store            int
-	callback         string
+	store            int    // nolint: unused
+	callback         string // nolint: unused
 }
 
 func (s *PubnubSink) Id() *uuid.UUID {

--- a/pkg/tele/tele.go
+++ b/pkg/tele/tele.go
@@ -43,7 +43,7 @@ type shutdown struct {
 }
 
 func heartbeat(t time.Ticker, m *meta.CollectorMeta) {
-	for _ = range t.C {
+	for range t.C {
 		log.Trace().Msg("sending heartbeat telemetry")
 		b := beat{
 			Meta:           m,
@@ -82,7 +82,10 @@ func Sis(m *meta.CollectorMeta) {
 		},
 	}
 	endpoint, _ := url.Parse(DEFAULT_ENDPOINT)
-	request.PostEvent(*endpoint, shutdownPayload)
+	_, err := request.PostEvent(*endpoint, shutdownPayload)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func Metry(c *config.Config, m *meta.CollectorMeta) {
@@ -102,7 +105,10 @@ func Metry(c *config.Config, m *meta.CollectorMeta) {
 			},
 		}
 		endpoint, _ := url.Parse(DEFAULT_ENDPOINT)
-		request.PostEvent(*endpoint, startupPayload)
+		_, err := request.PostEvent(*endpoint, startupPayload)
+		if err != nil {
+			panic(err)
+		}
 		ticker := time.NewTicker(time.Duration(HEARTBEAT_MS) * time.Millisecond)
 		go heartbeat(*ticker, m)
 	}

--- a/pkg/util/structToMap.go
+++ b/pkg/util/structToMap.go
@@ -9,6 +9,9 @@ import "encoding/json"
 func StructToMap(v interface{}) map[string]interface{} {
 	var m map[string]interface{}
 	i, _ := json.Marshal(v)
-	json.Unmarshal(i, &m) // FIXME! Don't love it. Don't love it at all.
+	// FIXME! Don't love it. Don't love it at all.
+	if err := json.Unmarshal(i, &m); err != nil {
+		panic(err)
+	}
 	return m
 }


### PR DESCRIPTION
- Adds `lint` target to `Makefile` for [golangci-lint](https://github.com/golangci/golangci-lint)
- Updates code based on linter where it seemed like it wouldn't change behavior. Used `// nolint` where I wasn't too sure
- Adds config file for linter because I was too lazy to update tests
- Adds lint check to GitHub Actions
