### PR TITLE
More gcp terraform additions

### DIFF
--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -1,34 +1,33 @@
 # Terraform GCP
 Deploy Buz to Google Cloud via Terraform.
 
-1. Create a file in this directory `terraform.tfvars`. Set the `gcp_project` and optionally set `gcp_region`.
-```
-gcp_project = "my-project-23456"
-gcp_region  = "us-central1" #default value
-```
+## Prerequisites
 
-2. In the command line authenticate GCP
+You will need `terraform` and `gcloud`.
+
+## Spinning up Buz
+
+**Auth Gcloud**
+
 ```
 gcloud auth application-default login
 ```
 
-3. Create the artifact registry
-```
-terraform plan -target=google_artifact_registry_repository.buz_repository
-```
 
-4. After your registry has been created. Upload the appropriate buz image
-```
-gcloud auth configure-docker us-central1-docker.pkg.dev
+**Apply Terraform**
 
-docker pull ghcr.io/silverton-io/buz:v0.11.11@sha256:130ed9421579125e4f38089e4c2d1e07038fb26591a15082010a52b95f3a5dda # amd64
-
-docker tag ghcr.io/silverton-io/buz:v0.11.11@sha256:130ed9421579125e4f38089e4c2d1e07038fb26591a15082010a52b95f3a5dda us-central1-docker.pkg.dev/{YOUR PROJECT NAME}/buz-repository/buz:v0.11.11
-
-docker push us-central1-docker.pkg.dev/{YOUR PROJECT NAME}/buz-repository/buz:v0.11.11
-```
-
-5. Deploy the rest of the buz stack
 ```
 terraform apply
+```
+
+**[Optional] - Create and populate terraform.tfvars**
+
+If you don't want to pass terraform variables interactively, you can optionally create a `terraform.tfvars` file in this directory and populate it:
+
+```
+gcp_project = "my-project-23456"
+gcp_region  = "us-central1"
+system      = "buz"
+buz_domain  = "track.yourdomain.com"
+buz_version = "v0.11.11"
 ```

--- a/terraform/gcp/config.tftpl
+++ b/terraform/gcp/config.tftpl
@@ -1,11 +1,11 @@
 version: 1.1
 
 app:
-  name: gcp-sample
-  env: development
+  name: ${system}
+  env: ${env}
   mode: debug
   port: 8080
-  trackerDomain: gcp.sample # FIXME
+  trackerDomain: ${trackerDomain}
   enableConfigRoute: true
 
 middleware:
@@ -22,14 +22,14 @@ middleware:
       name: nuid
       secure: true
       ttlDays: 365
-      domain: .gcp.sample # FIXME
+      domain: .${cookieDomain}
       path: /
       sameSite: None
     fallback: 00000000-0000-4000-A000-000000000000
   cors:
     enabled: true
     allowOrigin:
-      - "*" # FIXME
+      - "*"
     allowCredentials: true
     allowMethods:
       - POST
@@ -71,16 +71,16 @@ inputs:
 schemaCache:
   backend:
     type: gcs
-    bucket: buz-schemas-640041769530
+    bucket: ${schemaBucket}
     path: /
 
 sinks:
   - name: primary
     type: pubsub
     deliveryRequired: true
-    validTopic: buz-valid
-    invalidTopic: buz-invalid
-    project: silverton-docs # FIXME
+    validTopic: ${validTopic}
+    invalidTopic: ${invalidTopic}
+    project: ${project}
   - name: secondary
     type: stdout
     deliveryRequired: true

--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -1,11 +1,15 @@
 locals {
-  buz_config_path       = "HONEYPOT_CONFIG_PATH"
-  buz_config_path_value = "/etc/buz"
+  buz_config_var  = "HONEYPOT_CONFIG_PATH"
+  buz_config_path = "/etc/buz"
   activate_apis = [
     "artifactregistry.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com"
   ]
-  domainParts  = split(".", var.buz_domain)
-  cookieDomain = join(".", slice(local.domainParts, 1, length(local.domainParts))) # Assumes Buz is running on a subdomain and the cookie should be on root
+  domain_parts                 = split(".", var.buz_domain)
+  cookie_domain                = join(".", slice(local.domain_parts, 1, length(local.domain_parts))) # Assumes Buz is running on a subdomain and the cookie should be on root
+  artifact_registry_root       = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}"
+  artifact_registry_repository = "${var.system}-repository"
+  buz_source_image             = "ghcr.io/silverton-io/buz:${var.buz_version}"
+  buz_image                    = "${local.artifact_registry_root}/${local.artifact_registry_repository}/buz:${var.buz_version}"
 }

--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -1,6 +1,11 @@
 locals {
-  buz_sha               = "sha256:1083c0333c284dfa16dd7cc621f90b8a1197fe4d9905237e41f2f1a495481d92"
   buz_config_path       = "HONEYPOT_CONFIG_PATH"
   buz_config_path_value = "/etc/buz"
-  domain                = "honey.buz.dev"
+  activate_apis = [
+    "artifactregistry.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com"
+  ]
+  domainParts  = split(".", var.buz_domain)
+  cookieDomain = join(".", slice(local.domainParts, 1, length(local.domainParts))) # Assumes Buz is running on a subdomain and the cookie should be on root
 }

--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -8,7 +8,8 @@ locals {
   ]
   domain_parts                 = split(".", var.buz_domain)
   cookie_domain                = join(".", slice(local.domain_parts, 1, length(local.domain_parts))) # Assumes Buz is running on a subdomain and the cookie should be on root
-  artifact_registry_root       = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}"
+  artifact_registry_location   = "${var.gcp_region}-docker.pkg.dev"
+  artifact_registry_root       = "${local.artifact_registry_location}/${var.gcp_project}"
   artifact_registry_repository = "${var.system}-repository"
   buz_source_image             = "ghcr.io/silverton-io/buz:${var.buz_version}"
   buz_image                    = "${local.artifact_registry_root}/${local.artifact_registry_repository}/buz:${var.buz_version}"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -77,6 +77,7 @@ resource "null_resource" "pull_and_push_image" {
     command = "docker pull ${local.buz_source_image} --platform=linux/amd64 && docker tag ${local.buz_source_image} ${local.buz_image} && docker push ${local.buz_image}"
   }
   depends_on = [
+    google_artifact_registry_repository.buz_repository,
     null_resource.configure_docker
   ]
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -63,12 +63,21 @@ resource "google_artifact_registry_repository" "buz_repository" {
   ]
 }
 
-resource "null_resource" "pull_and_push_image" {
+resource "null_resource" "configure_docker" {
   provisioner "local-exec" {
-    command = "docker pull ${local.buz_source_image} && docker tag ${local.buz_source_image} ${local.buz_image} && docker push ${local.buz_image}"
+    command = "gcloud auth configure-docker ${local.artifact_registry_location} -y"
   }
   depends_on = [
     google_artifact_registry_repository.buz_repository
+  ]
+}
+
+resource "null_resource" "pull_and_push_image" {
+  provisioner "local-exec" {
+    command = "docker pull ${local.buz_source_image} --platform=linux/amd64 && docker tag ${local.buz_source_image} ${local.buz_image} && docker push ${local.buz_image}"
+  }
+  depends_on = [
+    null_resource.configure_docker
   ]
 }
 

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,10 +1,3 @@
-locals {
-  activate_apis = [
-    "artifactregistry.googleapis.com",
-    "run.googleapis.com",
-    "secretmanager.googleapis.com"
-  ]
-}
 
 data "google_project" "project" {}
 
@@ -23,15 +16,15 @@ resource "google_storage_bucket" "buz_schemas" {
 }
 
 resource "google_pubsub_topic" "valid_topic" {
-  name = "buz-valid"
+  name = "${var.system}-${var.valid_topic_name}"
 }
 
 resource "google_pubsub_topic" "invalid_topic" {
-  name = "buz-invalid"
+  name = "${var.system}-${var.invalid_topic_name}"
 }
 
 resource "google_secret_manager_secret" "buz_config" {
-  secret_id = "buz-config"
+  secret_id = "${var.system}-config"
 
   replication {
     user_managed {
@@ -47,13 +40,22 @@ resource "google_secret_manager_secret" "buz_config" {
 }
 
 resource "google_secret_manager_secret_version" "buz_config" {
-  secret      = google_secret_manager_secret.buz_config.id
-  secret_data = file("gcp.yml")
+  secret = google_secret_manager_secret.buz_config.id
+  secret_data = templatefile("config.tftpl", {
+    project       = var.gcp_project,
+    system        = var.system,
+    env           = var.env,
+    trackerDomain = var.buz_domain,
+    cookieDomain  = local.cookieDomain,
+    schemaBucket  = google_storage_bucket.buz_schemas.name,
+    validTopic    = google_pubsub_topic.valid_topic.name,
+    invalidTopic  = google_pubsub_topic.invalid_topic.name,
+  })
 }
 
 resource "google_artifact_registry_repository" "buz_repository" {
   location      = var.gcp_region
-  repository_id = "buz-repository"
+  repository_id = "${var.system}-repository"
   format        = "DOCKER"
 
   depends_on = [
@@ -79,7 +81,7 @@ resource "google_project_iam_binding" "buz_config_secret_access" {
 }
 
 resource "google_cloud_run_service" "buz" {
-  name     = "buz"
+  name     = var.system
   location = var.gcp_region
 
   template {
@@ -88,7 +90,7 @@ resource "google_cloud_run_service" "buz" {
       container_concurrency = 80
 
       volumes {
-        name = "buz-config"
+        name = "${var.system}-config"
         secret {
           secret_name = google_secret_manager_secret.buz_config.secret_id
           items {
@@ -99,7 +101,7 @@ resource "google_cloud_run_service" "buz" {
       }
 
       containers {
-        image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/buz-repository/buz@${local.buz_sha}"
+        image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/${var.system}-repository/buz@${var.buz_image_sha}"
 
         resources {
           limits = {
@@ -118,7 +120,7 @@ resource "google_cloud_run_service" "buz" {
         }
 
         volume_mounts {
-          name       = "buz-config"
+          name       = "${var.system}-config"
           mount_path = local.buz_config_path_value
         }
       }
@@ -151,8 +153,8 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 }
 
 resource "google_cloud_run_domain_mapping" "buz" {
-  location = "us-central1"
-  name     = local.domain
+  location = var.gcp_region
+  name     = var.buz_domain
 
   metadata {
     namespace = data.google_project.project.project_id

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -11,9 +11,8 @@ variable "gcp_region" {
 }
 
 variable "system" {
-  description = "The name of the Buz implementation"
+  description = "The name of the Buz implementation. \n\nExample: buz"
   type        = string
-  default     = "buzzy"
 }
 
 variable "env" {
@@ -23,15 +22,13 @@ variable "env" {
 }
 
 variable "buz_domain" {
-  description = "The domain or subdomain to map Buz to"
+  description = "The subdomain to map Buz to. \n\nExample: track.yourdomain.com"
   type        = string
-  default     = "b.buz.dev"
 }
 
 variable "buz_version" {
-  description = "The version of Buz to run"
+  description = "The version of Buz to run. \n\nExample: v0.11.11"
   type        = string
-  default     = "v0.11.11"
 }
 
 variable "valid_topic_name" {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -8,3 +8,38 @@ variable "gcp_region" {
   type        = string
   default     = "us-central1"
 }
+
+variable "system" {
+  description = "The name of the Buz implementation"
+  type        = string
+  default     = "buzzy"
+}
+
+variable "env" {
+  description = "The name of the Buz environment"
+  type        = string
+  default     = "dev"
+}
+
+variable "buz_domain" {
+  description = "The domain or subdomain to map Buz to"
+  type        = string
+}
+
+variable "buz_image_sha" {
+  description = "The Buz image SHA"
+  type        = string
+  default     = "sha256:1083c0333c284dfa16dd7cc621f90b8a1197fe4d9905237e41f2f1a495481d92"
+}
+
+variable "valid_topic_name" {
+  description = "The name of the Pub/Sub topic for valid events"
+  type        = string
+  default     = "valid-events"
+}
+
+variable "invalid_topic_name" {
+  description = "The name of the Pub/Sub topic for invalid events"
+  type        = string
+  default     = "invalid-events"
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,6 +1,7 @@
 variable "gcp_project" {
   description = "GCloud Project ID"
   type        = string
+  default     = "silvertonio"
 }
 
 variable "gcp_region" {
@@ -24,12 +25,13 @@ variable "env" {
 variable "buz_domain" {
   description = "The domain or subdomain to map Buz to"
   type        = string
+  default     = "b.buz.dev"
 }
 
-variable "buz_image_sha" {
-  description = "The Buz image SHA"
+variable "buz_version" {
+  description = "The version of Buz to run"
   type        = string
-  default     = "sha256:1083c0333c284dfa16dd7cc621f90b8a1197fe4d9905237e41f2f1a495481d92"
+  default     = "v0.11.11"
 }
 
 variable "valid_topic_name" {


### PR DESCRIPTION
This PR:

1. Splices resources through to the (now templated) config file
2. Consolidates some `locals`
3. Adds `system` and `env` vars
4. Shuffles some existing `locals` to `vars` so they can be overridden as required (buz sha, etc)
5. Allows for `valid` and `invalid` topic names to be overridden