### PR TITLE
Mark optional Snowplow properties as optional in schema definitions

### DIFF
--- a/schemas/io.silverton/snowplow/struct/v1.0.json
+++ b/schemas/io.silverton/snowplow/struct/v1.0.json
@@ -19,18 +19,18 @@
             "description": "The struct event action"
         },
         "se_label": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The struct event label"
         },
         "se_property": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The struct event property"
         },
         "se_value": {
-            "type": "number",
+            "type": ["string","null"],
             "description": "The struct event value"
         }
     },
-    "required": [],
+    "required": ["se_category", "se_action"],
     "additionalProperties": false
 }

--- a/schemas/io.silverton/snowplow/transaction/v1.0.json
+++ b/schemas/io.silverton/snowplow/transaction/v1.0.json
@@ -15,7 +15,7 @@
             "description": "The transaction order id"
         },
         "tr_affiliation": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The transaction affiliation"
         },
         "tr_total": {
@@ -23,30 +23,30 @@
             "description": "The transaction total"
         },
         "tr_tax": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction tax"
         },
         "tr_shipping": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction shipping"
         },
         "tr_city": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction city"
         },
         "tr_state": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction state"
         },
         "tr_country": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction country"
         },
         "tr_currency": {
-            "type": "number",
+            "type": ["number","null"],
             "description": "The transaction currency"
         }
     },
-    "required": [],
+    "required": ["tr_orderid", "tr_total"],
     "additionalProperties": false
 }

--- a/schemas/io.silverton/snowplow/transaction_item/v1.0.json
+++ b/schemas/io.silverton/snowplow/transaction_item/v1.0.json
@@ -19,11 +19,11 @@
             "description": "The transaction item sku"
         },
         "ti_name": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The transaction item name"
         },
         "ti_category": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The transaction item category"
         },
         "ti_price": {
@@ -35,7 +35,7 @@
             "description": "The transaction item quantity"
         },
         "ti_currency": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "The transaction item currency"
         }
     },


### PR DESCRIPTION
Based on the [Snowplow Tracker Protocol spec][1], and what is marked as required or not in the [SDK docs][2].

I've tested this with our deployment and the [snowplow-python-tracker][3] and it works as I'd expect.

[1]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/
[2]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracking-specific-events/
[3]: https://github.com/snowplow/snowplow-python-tracker
