### PR TITLE
Wipe the erroneous git submodule

### DIFF
--- a/examples/quickstart/buz/quickstart.conf.yml
+++ b/examples/quickstart/buz/quickstart.conf.yml
@@ -88,18 +88,16 @@ registry:
     enabled: true
 
 sinks:
+  - name: stdout
+    type: stdout
+    deliveryRequired: true
   - name: primary
     type: kafka
     deliveryRequired: true
-    kafkaBrokers:
+    brokers:
       - redpanda-1:29092 # internally advertised
       - redpanda-2:29093 # internally advertised
       - redpanda-3:29094 # internally advertised
-    invalidTopic: hpt-invalid
-    validTopic: hpt-valid
-  - name: secondary
-    type: stdout
-    deliveryRequired: true
 
 squawkBox:
   enabled: true

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -20,7 +20,7 @@ x-dependency:
 services:
   buz:
     container_name: buz
-    image: ghcr.io/silverton-io/buz:v0.13.1
+    image: ghcr.io/silverton-io/buz:v0.13.2
     volumes:
       - type: bind
         source: ./buz/quickstart.conf.yml
@@ -30,6 +30,7 @@ services:
         target: /schemas/
     environment:
       - BUZ_CONFIG_PATH=/etc/buz/config.yml
+      - DEBUG=1
     ports:
       - 8080:8080
     deploy:


### PR DESCRIPTION
[This commit](https://github.com/silverton-io/buz/commit/36f6e6dd1ad656c56496280fcf82a8ab44fdaf82) added a git submodule `buz`: 

<img width="458" alt="Screenshot 2023-03-13 at 10 30 17 PM" src="https://user-images.githubusercontent.com/2599880/224877523-2ff3e851-f1b9-4087-9956-21f46204e074.png">

And i completely failed to see it.

Then, when [this line](https://github.com/silverton-io/buz/blob/main/deploy/Dockerfile#L9) tried to output a binary called `buz` during the multi-stage docker build, it failed to do so because there was a git submodule of the same name. Non ideal.

I've removed the git submodule from the project, and all is well now.

