### PR TITLE
Use Bigquery streaming inserts in default gcp deployment

### DIFF
--- a/deploy/terraform/gcp/cloud_run/config.yml.tftpl
+++ b/deploy/terraform/gcp/cloud_run/config.yml.tftpl
@@ -85,9 +85,10 @@ registry:
 
 sinks:
   - name: primary
-    type: pubsub
+    type: bigquery
     deliveryRequired: true
     project: ${project}
+    dataset: ${dataset}
     defaultOutput: ${defaultOutput}
     deadletterOutput: ${deadletterOutput}
 

--- a/examples/devel/buz/simple.conf.yml
+++ b/examples/devel/buz/simple.conf.yml
@@ -192,6 +192,13 @@ sinks:
   #   apiKey: abdf41b4-f6e8-46a7-bb80-d349181af78c
   #   defaultOutput: main # This is tied to splunk HEC so it's moot
   #   deadletterOutput: main # This is tied to splunk HEC so it's moot
+  # - name: bigquery
+  #   type: bigquery
+  #   deliveryRequired: true
+  #   project: $YOUR_PROJECT
+  #   dataset: buz
+  #   defaultOutput: events
+  #   deadletterOutput: invalid_events
 
 squawkBox:
   enabled: true

--- a/schemas/io.silverton/buz/internal/config/app/v1.0.json
+++ b/schemas/io.silverton/buz/internal/config/app/v1.0.json
@@ -819,7 +819,8 @@
                             "nats",
                             "amplitude",
                             "eventbridge",
-                            "splunk"
+                            "splunk",
+                            "bigquery"
                         ]
                     },
                     "deliveryRequired": {
@@ -839,6 +840,11 @@
                         "type": "string",
                         "default": "buz-gcp-project",
                         "description": "The name of the GCP project"
+                    },
+                    "dataset": {
+                        "type": "string",
+                        "default": "buz-gcp-dataset",
+                        "description": "The name of the BigQuery dataset"
                     },
                     "url": {
                         "type": "string",
@@ -1151,12 +1157,23 @@
                     {
                         "properties": {
                             "type": {
-                                "const": "amplitude"
+                                "const": "splunk"
                             }
                         },
                         "required": [
-                            "apiKey",
-                            "region"
+                            "url",
+                            "apiKey"
+                        ]
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "bigquery"
+                            }
+                        },
+                        "required": [
+                            "project",
+                            "dataset"
                         ]
                     }
                 ]


### PR DESCRIPTION
Buz now:

- Uses Bigquery streaming inserts by default when running on GCP
- Has validated config for the splunk ,eventbridge, and bigquery sinks