### PR TITLE
feat: add alternate schema route

### DIFF
--- a/cmd/buz/app.go
+++ b/cmd/buz/app.go
@@ -176,6 +176,9 @@ func (a *App) initializeSchemaCacheRoutes() {
 	if a.config.Registry.Http.Enabled {
 		log.Info().Msg("🟢 initializing schema registry routes")
 		a.switchableRouterGroup.GET(registry.SCHEMAS_ROUTE+"*"+registry.SCHEMA_PARAM, registry.GetSchemaHandler(r))
+		if a.config.SchemaRoute != "" {
+			a.switchableRouterGroup.GET(a.config.SchemaRoute+"*"+registry.SCHEMA_PARAM, registry.GetSchemaHandler(r))
+		}
 	}
 }
 

--- a/deploy/terraform/aws/lambda/config.yml.tftpl
+++ b/deploy/terraform/aws/lambda/config.yml.tftpl
@@ -7,6 +7,7 @@ app:
   trackerDomain: ${trackerDomain}
   enableConfigRoute: false
   serverless: true
+  schemaRoute: /schemas/
 
 middleware:
   timeout:

--- a/deploy/terraform/gcp/cloud_run/config.yml.tftpl
+++ b/deploy/terraform/gcp/cloud_run/config.yml.tftpl
@@ -7,6 +7,7 @@ app:
   trackerDomain: ${trackerDomain}
   enableConfigRoute: false
   serverless: false
+  schemaRoute: /schemas/
 
 middleware:
   timeout:

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -12,4 +12,5 @@ type App struct {
 	TrackerDomain     string `json:"trackerDomain"`
 	EnableConfigRoute bool   `json:"enableConfigRoute"`
 	Serverless        bool   `json:"serverless"`
+	SchemaRoute       string `json:"schemaRoute"`
 }


### PR DESCRIPTION
Some tools (like the Snowplow chrome extension debugger) rely on the fact that the schema route is `/schemas/`.
I added a solution to keep the existing route (to preserve retro compatibility) and add a new one