### PR TITLE
feat: more lambda config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ examples/quickstart/minio/*
 .terraform.lock.hcl
 .terraform.tfstate.lock*
 terraform.*
+backend.tf
 build/buz
 *.build
 target/*

--- a/deploy/terraform/aws/lambda/locals.tf
+++ b/deploy/terraform/aws/lambda/locals.tf
@@ -1,19 +1,20 @@
 locals {
-  domain_parts        = split(".", var.buz_domain)
-  cookie_domain       = join(".", slice(local.domain_parts, 1, length(local.domain_parts))) # Assumes Buz is running on a subdomain and the cookie should be on root
-  buz_debug_var       = "DEBUG"
-  buz_config_var      = "BUZ_CONFIG_PATH"
-  buz_config_path     = "/etc/buz/config.yml"
-  system_env_base     = "${var.system}-${var.env}-"
-  artifact_repository = "${local.system_env_base}img"
-  image               = "buz:${var.buz_version}"
-  buz_source_image    = "ghcr.io/silverton-io/${local.image}"
-  service_name        = "${local.system_env_base}collector"
-  config              = "${local.system_env_base}config"
-  schema_bucket       = "${local.system_env_base}${var.schema_bucket_name}"
-  events_bucket       = "${local.system_env_base}${var.events_bucket_name}"
-  default_output        = "buz_events"
-  deadletter_output      = "buz_invalid_events"
+  domain_parts               = split(".", var.buz_domain)
+  cookie_domain              = join(".", slice(local.domain_parts, 1, length(local.domain_parts))) # Assumes Buz is running on a subdomain and the cookie should be on root
+  buz_debug_var              = "DEBUG"
+  buz_config_var             = "BUZ_CONFIG_PATH"
+  buz_config_path            = "/etc/buz/config.yml"
+  system_env_base            = "${var.system}-${var.env}-"
+  artifact_repository        = "${local.system_env_base}img"
+  image                      = "buz:${var.buz_version}"
+  buz_source_image           = "${var.buz_image_repo}/${local.image}"
+  service_name               = "${local.system_env_base}collector"
+  policy_name                = "${local.system_env_base}policy"
+  config                     = "${local.system_env_base}config"
+  schema_bucket              = "${local.system_env_base}${var.schema_bucket_name}"
+  events_bucket              = "${local.system_env_base}${var.events_bucket_name}"
+  default_output             = "buz_events"
+  deadletter_output          = "buz_invalid_events"
   metadata_extraction_params = "{isValid:.isValid,vendor:.vendor,namespace:.namespace,version:.version}"
-  s3_dynamic_prefix   = "isValid=!{partitionKeyFromQuery:isValid}/vendor=!{partitionKeyFromQuery:vendor}/namespace=!{partitionKeyFromQuery:namespace}/version=!{partitionKeyFromQuery:version}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/"
+  s3_dynamic_prefix          = "isValid=!{partitionKeyFromQuery:isValid}/vendor=!{partitionKeyFromQuery:vendor}/namespace=!{partitionKeyFromQuery:namespace}/version=!{partitionKeyFromQuery:version}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/"
 }

--- a/deploy/terraform/aws/lambda/locals.tf
+++ b/deploy/terraform/aws/lambda/locals.tf
@@ -9,7 +9,6 @@ locals {
   image                      = "buz:${var.buz_version}"
   buz_source_image           = "${var.buz_image_repo}/${local.image}"
   service_name               = "${local.system_env_base}collector"
-  policy_name                = "${local.system_env_base}policy"
   config                     = "${local.system_env_base}config"
   schema_bucket              = "${local.system_env_base}${var.schema_bucket_name}"
   events_bucket              = "${local.system_env_base}${var.events_bucket_name}"

--- a/deploy/terraform/aws/lambda/provider.tf
+++ b/deploy/terraform/aws/lambda/provider.tf
@@ -10,5 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  region = var.aws_region
+  region     = var.aws_region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
 }

--- a/deploy/terraform/aws/lambda/provider.tf
+++ b/deploy/terraform/aws/lambda/provider.tf
@@ -10,7 +10,6 @@ terraform {
 }
 
 provider "aws" {
-  region     = var.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
+  region  = var.aws_region
+  profile = var.aws_profile
 }

--- a/deploy/terraform/aws/lambda/variables.tf
+++ b/deploy/terraform/aws/lambda/variables.tf
@@ -4,14 +4,10 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "aws_access_key" {
-  description = "AWS Access Key"
+variable "aws_profile" {
+  description = "AWS Profile"
   type        = string
-}
-
-variable "aws_secret_key" {
-  description = "AWS Secret Key"
-  type        = string
+  default     = "default"
 }
 
 variable "system" {

--- a/deploy/terraform/aws/lambda/variables.tf
+++ b/deploy/terraform/aws/lambda/variables.tf
@@ -4,6 +4,16 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "aws_access_key" {
+  description = "AWS Access Key"
+  type        = string
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+  type        = string
+}
+
 variable "system" {
   description = "The name of the Buz implementation. \n\nExample: buz"
   type        = string
@@ -24,6 +34,12 @@ variable "debug" {
 variable "buz_domain" {
   description = "The subdomain to map Buz to. \n\nExample: track.yourdomain.com"
   type        = string
+}
+
+variable "buz_image_repo" {
+  description = "The Buz image repository"
+  type        = string
+  default     = "ghcr.io/silverton-io"
 }
 
 variable "buz_version" {


### PR DESCRIPTION
Added new features to make the Lambda terraform config more versatile:

- Use the new cache policy system (since the previous is deprecated)
- Use the new cors policy system (deprecated + and did not forward the right headers)
- Remove geo_restriction because it is specific, not documented and hard to debug
- Add aws_access_key / aws_secret_key for easier setup
- Allow to use custom buz_source_image
- bug fix: with build_number = var.buz_version, I have an error because the docker login only last a few hours so it needs to run every time -> my solution isn't very clean but I'm not really a pro in Terraform so tell me if you have a better solution !