### PR TITLE
feat: extend cors

### DIFF
--- a/pkg/middleware/cors.go
+++ b/pkg/middleware/cors.go
@@ -15,8 +15,23 @@ import (
 
 func CORS(conf config.Cors) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Header("Access-Control-Allow-Origin", strings.Join(conf.AllowOrigin, ", "))
-		c.Header("Access-Control-Allow-Credentials", strconv.FormatBool(conf.AllowCredentials))
+		origin := c.Request.Header.Get("Origin")
+
+		for _, domain := range conf.AllowOrigin {
+			if domain == "*" {
+				c.Header("Access-Control-Allow-Origin", origin)
+				break
+			}
+			if strings.HasSuffix(origin, domain) {
+				c.Header("Access-Control-Allow-Origin", origin)
+				break
+			}
+		}
+
+		if strconv.FormatBool(conf.AllowCredentials) == "true" {
+			c.Header("Access-Control-Allow-Credentials", strconv.FormatBool(conf.AllowCredentials))
+		}
+
 		c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With, Set-Cookie, Cookie")
 		c.Header("Access-Control-Allow-Methods", strings.Join(conf.AllowMethods, ", "))
 		c.Header("Access-Control-Max-Age", strconv.Itoa(conf.MaxAge))
@@ -25,6 +40,7 @@ func CORS(conf config.Cors) gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
+
 		c.Next()
 	}
 }


### PR DESCRIPTION
Allow CORS for any subdomain which is not currently possible + only mentions "Access-Control-Allow-Credentials" when it's true because that's the recommendation