### PR TITLE
feat: add support for AWS Profile for aws ecr get-login-password cmd

### DIFF
--- a/deploy/terraform/aws/lambda/main.tf
+++ b/deploy/terraform/aws/lambda/main.tf
@@ -142,7 +142,7 @@ resource "null_resource" "configure_docker" {
     always_run = timestamp()
   }
   provisioner "local-exec" {
-    command = "aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com"
+    command = "aws ecr get-login-password --region ${var.aws_region} --profile ${var.aws_profile} | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com"
   }
   depends_on = [
     aws_ecr_repository.buz_repository


### PR DESCRIPTION
I've added the `--profile` parameter w/ value from `${var.aws_profile}` variable to the `aws ecr get-login-password…` command to support setting/ overwriting this in `terraform.tfvars`.