### PR TITLE
WIP add materialize webhook source as buz sink

### DIFF
--- a/pkg/backend/materializewebhook/registry.go
+++ b/pkg/backend/materializewebhook/registry.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 Silverton Data, Inc.
+// You may use, distribute, and modify this code under the terms of the Apache-2.0 license, a copy of
+// which may be found at https://github.com/silverton-io/buz/blob/main/LICENSE
+
+package materializewebhook
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/silverton-io/buz/pkg/backend/postgresdb"
+	"github.com/silverton-io/buz/pkg/config"
+	"github.com/silverton-io/buz/pkg/db"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type RegistryBackend struct {
+	gormDb        *gorm.DB
+	registryTable string
+}
+
+func (b *RegistryBackend) Initialize(conf config.Backend) error {
+	connParams := db.ConnectionParams{
+		Host: conf.DbHost,
+		Port: conf.DbPort,
+		Db:   conf.DbName,
+		User: conf.DbUser,
+		Pass: conf.DbPass,
+	}
+	connString := postgresdb.GenerateDsn(connParams)
+	gormDb, err := gorm.Open(postgres.Open(connString), &gorm.Config{})
+	if err != nil {
+		log.Error().Err(err).Msg("🔴 could not open pg connection")
+		return err
+	}
+	b.gormDb, b.registryTable = gormDb, conf.RegistryTable
+	ensureErr := db.EnsureMaterializeWebhookSource(b.gormDb, b.registryTable, conf.WebhookSecret, conf.Cluster, db.RegistryTable{})
+	return ensureErr
+}
+
+func (b *RegistryBackend) GetRemote(schema string) (contents []byte, err error) {
+	var s db.RegistryTable
+	b.gormDb.Table(b.registryTable).Where("name = ?", schema).First(&s)
+	err = b.gormDb.Error
+	if err != nil {
+		return nil, err
+	}
+	return s.Contents, nil
+}
+
+func (b *RegistryBackend) Close() {
+	log.Info().Msg("🟢 closing postgres schema cache backend")
+}

--- a/pkg/backend/materializewebhook/sink.go
+++ b/pkg/backend/materializewebhook/sink.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2023 Silverton Data, Inc.
+// You may use, distribute, and modify this code under the terms of the Apache-2.0 license, a copy of
+// which may be found at https://github.com/silverton-io/buz/blob/main/LICENSE
+
+package materializewebhook
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"github.com/silverton-io/buz/pkg/backend/backendutils"
+	"github.com/silverton-io/buz/pkg/backend/postgresdb"
+	"github.com/silverton-io/buz/pkg/config"
+	"github.com/silverton-io/buz/pkg/db"
+	"github.com/silverton-io/buz/pkg/envelope"
+	"github.com/silverton-io/buz/pkg/request"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"net/url"
+
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+)
+
+type Sink struct {
+	metadata backendutils.SinkMetadata
+	gormDb   *gorm.DB
+	input    chan []envelope.Envelope
+	shutdown chan int
+	host     string
+	apiKey   string
+}
+
+func (s *Sink) Metadata() backendutils.SinkMetadata {
+	return s.metadata
+}
+
+func (s *Sink) Initialize(conf config.Sink) error {
+	s.metadata = backendutils.NewSinkMetadataFromConfig(conf)
+	connParams := db.ConnectionParams{
+		Host: conf.Hosts[0], //Only use the first configured host.
+		Port: conf.Port,
+		Db:   conf.Database,
+		User: conf.User,
+		Pass: conf.Password,
+	}
+	s.host = conf.Hosts[0]
+	s.apiKey = conf.ApiKey
+	connString := postgresdb.GenerateDsn(connParams)
+	gormDb, err := gorm.Open(postgres.Open(connString), &gorm.Config{})
+	if err != nil {
+		log.Error().Err(err).Msg("🔴 could not open " + s.metadata.SinkType + " connection")
+		return err
+	}
+	s.gormDb = gormDb
+	s.input = make(chan []envelope.Envelope, 10000)
+	s.shutdown = make(chan int, 1)
+	for _, tbl := range []string{s.metadata.DefaultOutput, s.metadata.DeadletterOutput} {
+		ensureErr := db.EnsureMaterializeWebhookSource(s.gormDb, tbl, conf.WebhookSecret, conf.Cluster, &envelope.JsonbEnvelope{})
+		if ensureErr != nil {
+			return ensureErr
+		}
+	}
+	return nil
+}
+
+func (s *Sink) StartWorker() error {
+	err := backendutils.StartSinkWorker(s.input, s.shutdown, s)
+	return err
+}
+
+func (s *Sink) Enqueue(envelopes []envelope.Envelope) error {
+	log.Debug().Interface("metadata", s.Metadata()).Msg("enqueueing envelopes")
+	s.input <- envelopes
+	return nil
+}
+
+func (s *Sink) Dequeue(ctx context.Context, envelopes []envelope.Envelope, output string) error {
+	log.Debug().Interface("metadata", s.Metadata()).Msg("dequeueing envelopes")
+	key := []byte(s.apiKey)
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(""))
+	signature := hex.EncodeToString(h.Sum(nil))
+
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	header.Add("X-Signature", signature)
+
+	urlGenerated := fmt.Sprintf("https://%s/public/%s", s.host, output)
+	url, err := url.Parse(urlGenerated)
+	if err != nil {
+		log.Error().Err(err).Msg("🔴 " + output + " is not a valid url")
+		return err
+	}
+	_, err = request.PostEnvelopes(*url, envelopes, nil)
+	if err != nil {
+		log.Error().Err(err).Interface("metadata", s.Metadata()).Msg("🔴 could not dequeue payloads")
+	}
+	return err
+}
+
+func (s *Sink) Shutdown() error {
+	log.Debug().Interface("metadata", s.metadata).Msg("🟢 shutting down sink")
+	db, _ := s.gormDb.DB()
+	s.shutdown <- 1
+	err := db.Close()
+	return err
+}

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -29,6 +29,10 @@ type Backend struct {
 	DbName string `json:"-"`
 	DbUser string `json:"-"`
 	DbPass string `json:"-"`
+	// Materialize specific
+	Cluster       string `json:"cluster,omitempty"`
+	WebhookSecret string `json:"webhookApiKey,omitempty"`
+
 	// Mongodb
 	MongoHosts         []string `json:"mongoHosts,omitempty"`
 	MongoPort          string   `json:"mongoDbPort,omitempty"`

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -14,7 +14,7 @@ type Sink struct {
 	Project string `json:"project,omitempty"`
 	Dataset string `json:"dataset,omitempty"`
 	// Kafka
-	Brokers []string `json:"kakfaBrokers,omitempty"`
+	Brokers []string `json:"kafkaBrokers,omitempty"`
 	// Http / API
 	Url    string `json:"url"`
 	ApiKey string `json:"-"`
@@ -27,6 +27,9 @@ type Sink struct {
 	Database string   `json:"-"`
 	User     string   `json:"-"`
 	Password string   `json:"-"`
+	// Materialize specific
+	Cluster       string `json:"cluster,omitempty"`
+	WebhookSecret string `json:"webhookApiKey,omitempty"`
 	// Pubnub
 	PubnubPubKey string `json:"pubnubPubKey,omitempty"`
 	PubnubSubKey string `json:"pubnubSubKey,omitempty"`

--- a/pkg/constants/backend.go
+++ b/pkg/constants/backend.go
@@ -6,14 +6,15 @@ package constants
 
 const (
 	// Databases
-	POSTGRES      string = "postgres"
-	MYSQL         string = "mysql"
-	MATERIALIZE   string = "materialize"
-	CLICKHOUSE    string = "clickhouse"
-	MONGODB       string = "mongodb"
-	ELASTICSEARCH string = "elasticsearch"
-	TIMESCALE     string = "timescale"
-	BIGQUERY      string = "bigquery"
+	POSTGRES            string = "postgres"
+	MYSQL               string = "mysql"
+	MATERIALIZE         string = "materialize"
+	MATERIALIZE_WEBHOOK string = "materializeWebhook"
+	CLICKHOUSE          string = "clickhouse"
+	MONGODB             string = "mongodb"
+	ELASTICSEARCH       string = "elasticsearch"
+	TIMESCALE           string = "timescale"
+	BIGQUERY            string = "bigquery"
 	// Streams and Queues
 	PUBSUB           string = "pubsub"
 	REDPANDA         string = "redpanda"

--- a/pkg/db/util.go
+++ b/pkg/db/util.go
@@ -5,8 +5,13 @@
 package db
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
+	"reflect"
+	"strings"
+	"time"
 )
 
 // EnsureTable creates a table according to the specified model if it
@@ -23,4 +28,117 @@ func EnsureTable(gormDb *gorm.DB, tableName string, model interface{}) error {
 		log.Debug().Msg("🟡 " + tableName + " table already exists - not creating")
 	}
 	return nil
+}
+
+func EnsureMaterializeWebhookSource(gormDb *gorm.DB, sourceName string, apiKey string, cluster string, model interface{}) error {
+
+	query, err := _generateJsonbQuery(fmt.Sprintf("%s_source", sourceName), "body", model)
+	if err != nil {
+		log.Error().Err(err).Msg("🔴 could not generate view query for " + sourceName)
+		return err
+	}
+
+	createStatement := fmt.Sprintf(`
+		CREATE SECRET IF NOT EXISTS %s_secret AS '%s';
+		CREATE SOURCE %s IN CLUSTER %s_source FROM WEBHOOK
+		BODY FORMAT JSON
+		CHECK (
+			WITH (
+			  HEADERS, BODY AS request_body,
+			  SECRET %s
+			)
+			constant_time_eq(
+			    decode(headers->'x-signature', 'base64'),
+			    hmac(request_body, %s_secret, 'sha256')
+			)
+		);
+		CREATE VIEW IF NOT EXISTS %s AS %s
+	`, sourceName, apiKey, sourceName, cluster, sourceName, sourceName, sourceName, query)
+
+	err = gormDb.Exec(createStatement).Error
+
+	if err != nil {
+		log.Error().Err(err).Msg("🔴 could not create " + sourceName + " source")
+		return err
+	}
+	return nil
+
+}
+
+// Just a guess
+func _generateJsonbQuery(tableName, jsonColumn string, structInstance interface{}) (string, error) {
+	var selectColumns []string
+
+	val := reflect.ValueOf(structInstance)
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		jsonTag := field.Tag.Get("json")
+		gormTag := field.Tag.Get("gorm")
+
+		if jsonTag == "" {
+			continue
+		}
+
+		// Handle omitempty for JSONB fields
+		if strings.Contains(jsonTag, ",omitempty") {
+			jsonTag = strings.Split(jsonTag, ",")[0]
+		}
+
+		// Handle multiple options in Gorm tag
+		gormOptions := strings.Split(gormTag, ";")
+		gormColumnName := jsonTag
+		gormType := ""
+
+		for _, option := range gormOptions {
+			parts := strings.Split(option, ":")
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+
+				switch key {
+				case "column":
+					gormColumnName = value
+				case "type":
+					gormType = value
+				}
+			}
+		}
+
+		if gormType == "" {
+			gormType = getGormType(field.Type)
+		}
+		if gormType == "json" {
+			gormType = "jsonb"
+		}
+
+		selectColumns = append(selectColumns, fmt.Sprintf(`"%s"."%s"->>'%s'::%s AS "%s"`, tableName, jsonColumn, jsonTag, gormType, gormColumnName))
+	}
+	if len(selectColumns) == 0 {
+		err := fmt.Errorf(`Could not generate query for "%s"`, tableName)
+		log.Error().Err(err).Msg("🔴 could not create " + tableName + " source")
+		return "", err
+	}
+
+	return fmt.Sprintf("SELECT %s FROM %s", strings.Join(selectColumns, ", "), tableName), nil
+}
+
+func getGormType(fieldType reflect.Type) string {
+	switch fieldType.Kind() {
+	case reflect.String:
+		return "text"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return "integer"
+	case reflect.Float32, reflect.Float64:
+		return "numeric"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Struct:
+		if fieldType == reflect.TypeOf(time.Time{}) {
+			return "timestamptz"
+		}
+	}
+
+	return "text"
 }

--- a/pkg/db/util_test.go
+++ b/pkg/db/util_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Silverton Data, Inc.
+// You may use, distribute, and modify this code under the terms of the Apache-2.0 license, a copy of
+// which may be found at https://github.com/silverton-io/buz/blob/main/LICENSE
+
+package db
+
+import (
+	// "github.com/silverton-io/buz/pkg/db"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// database tables with string columns.
+type StringEnvelope struct {
+	Uuid            uuid.UUID         `json:"uuid" gorm:"type:uuid"`
+	Timestamp       time.Time         `json:"timestamp" sql:"index"`
+	BuzVersion      string            `json:"buzVersion"`
+	IsValid         bool              `json:"isValid"`
+	ValidationError map[string]string `json:"validationError,omitempty" gorm:"type:json"`
+}
+
+func Test_generateJsonbQeury(t *testing.T) {
+	q, err := _generateJsonbQuery("foo", "bar", StringEnvelope{})
+	assert.Nil(t, err, "Error should be nil when generating jsonb query")
+	test_response := `SELECT "foo"."bar"->>'uuid'::uuid AS "uuid", "foo"."bar"->>'timestamp'::timestamptz AS "timestamp", "foo"."bar"->>'buzVersion'::text AS "buzVersion", "foo"."bar"->>'isValid'::boolean AS "isValid", "foo"."bar"->>'validationError'::jsonb AS "validationError" FROM foo`
+	assert.Equal(t, q, test_response)
+}

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -18,6 +18,7 @@ import (
 	"github.com/silverton-io/buz/pkg/backend/kafka"
 	"github.com/silverton-io/buz/pkg/backend/kinesis"
 	"github.com/silverton-io/buz/pkg/backend/kinesisFirehose"
+	"github.com/silverton-io/buz/pkg/backend/materializewebhook"
 	"github.com/silverton-io/buz/pkg/backend/mongodb"
 	"github.com/silverton-io/buz/pkg/backend/mysqldb"
 	"github.com/silverton-io/buz/pkg/backend/nats"
@@ -98,6 +99,10 @@ func getSink(conf config.Sink) (sink backendutils.Sink, err error) {
 		return &sink, nil
 	case constants.MATERIALIZE:
 		sink := postgresdb.Sink{}
+		return &sink, nil
+	case constants.MATERIALIZE_WEBHOOK:
+		sink :=
+			materializewebhook.Sink{}
 		return &sink, nil
 	case constants.SPLUNK:
 		sink := splunk.Sink{}


### PR DESCRIPTION
So far this is very much a WIP PR that was made in haste without testing, but could stand as a starting off point to integrating buz with Materialize's webhook sources. Webhook sources have some limitations, but ultimately should be a bit better/more performant than using Tables directly. 

https://materialize.com/docs/ingest-data/webhook-quickstart/


I'm not sure how to handle the schema/db names, or if the way I'm doing MZ view/source creation makes sense in this context.