### PR TITLE
Fix empty ports in Snowplow schema

### DIFF
--- a/pkg/protocol/snowplow/eventBuilder.go
+++ b/pkg/protocol/snowplow/eventBuilder.go
@@ -164,6 +164,12 @@ func getPageFromParam(params map[string]interface{}, k string) (Page, error) {
 		qParams := util.QueryToMap(parsedUrl.Query())
 		frag := parsedUrl.Fragment
 		port := parsedUrl.Port()
+		if port == "" {
+			port = "80"
+			if parsedUrl.Scheme == "https" {
+					port = "443"
+			}
+		}
 		page := Page{
 			Url:      p,
 			Scheme:   &parsedUrl.Scheme,


### PR DESCRIPTION
Go's net/url does not set the port if it's not explicitly provided in the URL being parsed. Snowplow behaviour is to set these for all events, so I added defaults. 